### PR TITLE
Install Ruby using the "chruby" cookbook

### DIFF
--- a/Berksfile
+++ b/Berksfile
@@ -4,5 +4,5 @@ cookbook "apt"
 cookbook "user"
 cookbook "sudo"
 cookbook "hub"
-cookbook "rvm", github: "fnichol/chef-rvm"
+cookbook "chruby", github: 'Atalanta/chef-chruby', ref: '1942bf89'
 cookbook "bosh_inception", path: "cookbooks/bosh_inception"

--- a/Berksfile.lock
+++ b/Berksfile.lock
@@ -1,9 +1,38 @@
-cookbook 'bosh_inception', :path => '/Users/drnic/Projects/ruby/gems/inception/cookbooks/bosh_inception'
-cookbook 'apt', :locked_version => '1.9.2'
-cookbook 'user', :locked_version => '0.3.0'
-cookbook 'sudo', :locked_version => '2.1.0'
-cookbook 'rvm', :git => 'git://github.com/fnichol/chef-rvm.git', :ref => '7038fb8c518d0d7785767de215b1ae463f237973'
-cookbook 'java', :locked_version => '1.10.2'
-cookbook 'windows', :locked_version => '1.8.10'
-cookbook 'chef_handler', :locked_version => '1.1.4'
-cookbook 'chef_gem', :locked_version => '0.1.0'
+{
+  "sha": "fb40c05441c1e2922b90c5f4c01c218404b906f9",
+  "sources": {
+    "apt": {
+      "locked_version": "1.9.2"
+    },
+    "user": {
+      "locked_version": "0.3.0"
+    },
+    "sudo": {
+      "locked_version": "2.1.0"
+    },
+    "hub": {
+      "locked_version": "1.0.4"
+    },
+    "rvm": {
+      "locked_version": "0.9.1",
+      "git": "git://github.com/fnichol/chef-rvm.git",
+      "ref": "7038fb8c518d0d7785767de215b1ae463f237973"
+    },
+    "bosh_inception": {
+      "locked_version": "0.1.0",
+      "path": "cookbooks/bosh_inception"
+    },
+    "java": {
+      "locked_version": "1.11.4"
+    },
+    "windows": {
+      "locked_version": "1.8.10"
+    },
+    "chef_handler": {
+      "locked_version": "1.1.4"
+    },
+    "chef_gem": {
+      "locked_version": "0.1.0"
+    }
+  }
+}

--- a/Berksfile.lock
+++ b/Berksfile.lock
@@ -1,5 +1,5 @@
 {
-  "sha": "fb40c05441c1e2922b90c5f4c01c218404b906f9",
+  "sha": "19980d38d2989f5d7806e39f23d8732fdb105ce6",
   "sources": {
     "apt": {
       "locked_version": "1.9.2"
@@ -13,26 +13,20 @@
     "hub": {
       "locked_version": "1.0.4"
     },
-    "rvm": {
-      "locked_version": "0.9.1",
-      "git": "git://github.com/fnichol/chef-rvm.git",
-      "ref": "7038fb8c518d0d7785767de215b1ae463f237973"
+    "chruby": {
+      "locked_version": "0.2.1",
+      "git": "git://github.com/Atalanta/chef-chruby.git",
+      "ref": "1942bf895b30b6173249d2a50f35e8efca1afc08"
     },
     "bosh_inception": {
       "locked_version": "0.1.0",
       "path": "cookbooks/bosh_inception"
     },
-    "java": {
-      "locked_version": "1.11.4"
+    "ark": {
+      "locked_version": "0.2.4"
     },
-    "windows": {
-      "locked_version": "1.8.10"
-    },
-    "chef_handler": {
-      "locked_version": "1.1.4"
-    },
-    "chef_gem": {
-      "locked_version": "0.1.0"
+    "ruby_build": {
+      "locked_version": "0.7.2"
     }
   }
 }

--- a/cookbooks/bosh_inception/attributes/default.rb
+++ b/cookbooks/bosh_inception/attributes/default.rb
@@ -7,17 +7,10 @@ default["disk"]["dir"] = "/var/vcap/store"
 default["user"]["username"] = `users | head -n 1`.strip
 default["git"]["name"] = "Nobody"
 default["git"]["email"] = "nobody@in-the-house.com"
-default["rvm"]["default_ruby"] = "ruby-1.9.3"
-default["rvm"]["global_gems"] = [
-  { "name"    => "bundler" },
-  { "name"    => "rake" },
-  { "name"    => "jazor" },
-  { "name"    => "yaml_command" },
-  { "name"    => "chef" },
-  { "name"    => "rubygems-bundler",
-    "action"  => "remove"
-  }
-]
+
+default["chruby"]["rubies"]["1.9.3-p392"] = false
+default["chruby"]["rubies"]["1.9.3-p429"] = true
+default["chruby"]["default"] = "1.9.3-p429"
 
 # Pass in credentials to be dropped into a ~/.fog file
 # They will be automatically converted to symbolized keys

--- a/cookbooks/bosh_inception/metadata.rb
+++ b/cookbooks/bosh_inception/metadata.rb
@@ -9,7 +9,7 @@ supports "ubuntu"
 
 depends "apt"
 depends "sudo"
-depends "rvm"
+depends "chruby"
 depends "hub"
 
 attribute "git",

--- a/cookbooks/bosh_inception/recipes/install_bosh.rb
+++ b/cookbooks/bosh_inception/recipes/install_bosh.rb
@@ -13,11 +13,10 @@ directory "/var/vcap/store/microboshes" do
   action :create
 end
 
-rvm_shell "install bosh micro" do
-  code "bundle install"
+bash "install bosh micro" do
   cwd "/var/vcap/store/microboshes"
-  # user node.user.username
-  # environment ({'HOME' => "/home/#{node.user.username}"})
+  user node.user.username
+  code "source /etc/profile.d/chruby.sh; bundle install"
   action :run
 end
 
@@ -28,10 +27,9 @@ cookbook_file "/var/vcap/store/systems/Gemfile" do
   mode "0644"
 end
 
-rvm_shell "install bosh cf" do
-  code "bundle install"
+bash "install bosh cf" do
   cwd "/var/vcap/store/systems"
-  # user node.user.username
-  # environment ({'HOME' => "/home/#{node.user.username}"})
+  user node.user.username
+  code "source /etc/profile.d/chruby.sh; bundle install"
   action :run
 end

--- a/cookbooks/bosh_inception/recipes/install_ruby.rb
+++ b/cookbooks/bosh_inception/recipes/install_ruby.rb
@@ -7,4 +7,14 @@
 # MIT License
 #
 
-include_recipe "rvm::system"
+include_recipe "chruby::system"
+
+bash "Install bundler"  do
+  versioned_bundler = "bundler -v '>= 1.3.5'"
+  code <<-BASH
+    source /etc/profile.d/chruby.sh
+    unset GEM_HOME
+    unset GEM_PATH
+    gem specification #{versioned_bundler} >/dev/null 2>&1 || gem install --no-rdoc --no-ri #{versioned_bundler}
+  BASH
+end

--- a/test/integration/default/bats/install_ruby.bats
+++ b/test/integration/default/bats/install_ruby.bats
@@ -2,9 +2,9 @@
 
 load discover_user
 
-expected_ruby_version = "1.9.3p429"
+expected_ruby_version="1.9.3p429"
 
-@test "ruby #{expected_ruby_version} is default" {
+@test "ruby $expected_ruby_version is default" {
   run su - $TEST_USER -c "ruby -v"
-  [ "$(echo ${lines[0]} | awk '{print $2}')" = expected_ruby_version ]
+  [ "$(echo ${lines[0]} | awk '{print $2}')" = $expected_ruby_version ]
 }

--- a/test/integration/default/bats/install_ruby.bats
+++ b/test/integration/default/bats/install_ruby.bats
@@ -2,7 +2,9 @@
 
 load discover_user
 
-@test "ruby 1.9.3p392 is default" {
+expected_ruby_version = "1.9.3p429"
+
+@test "ruby #{expected_ruby_version} is default" {
   run su - $TEST_USER -c "ruby -v"
-  [ "$(echo ${lines[0]} | awk '{print $2}')" = "1.9.3p392" ]
+  [ "$(echo ${lines[0]} | awk '{print $2}')" = expected_ruby_version ]
 }


### PR DESCRIPTION
This change replaces RVM with "chruby".  The main benefit is that it allows central management of Ruby interpreters (installed under /opt/rubies), while gems are installed in the user's home directory (under $HOME/.gem) by default.

This allows non-root users to "gem install" stuff, fixing cloudfoundry-community/inception-server#14.
