### PR TITLE
Share ssh access

### DIFF
--- a/inception-server.gemspec
+++ b/inception-server.gemspec
@@ -38,6 +38,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rspec"
 
   # gems for the cookbook tests
-  spec.add_development_dependency "test-kitchen", "~> 1.0.0.alpha.6"
+  spec.add_development_dependency "test-kitchen", "~> 1.0.0.beta.2"
   spec.add_development_dependency "berkshelf"
 end

--- a/inception-server.gemspec
+++ b/inception-server.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "cyoi" # choose your own infrastructure
 
   # for running cookbooks on inception server
-  spec.add_dependency "knife-solo", "~> 0.3.0.pre4"
+  spec.add_dependency "knife-solo", "~> 0.3.0"
 
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "rake"

--- a/lib/inception/cli.rb
+++ b/lib/inception/cli.rb
@@ -61,6 +61,35 @@ module Inception
       run_ssh_command_or_open_tunnel(["-t", "tmux attach || tmux new-session"])
     end
 
+    desc "share-ssh", "Display the SSH config & private key that can be given to others to share access to the inception server"
+    def share_ssh(name=settings.inception.name)
+      user = "vcap"
+      host = settings.inception.provisioned.host
+      private_key_path = "~/.ssh/#{name}"
+      private_key = settings.inception.key_pair.private_key
+      say <<-EOS
+To access the inception server, add the following to your ~/.ssh/config
+
+  Host #{name}
+    User #{user}
+    Hostname #{host}
+    IdentityFile #{private_key_path}
+
+Create a file #{private_key_path} with all the lines below:
+
+#{private_key}
+
+Change the private key to be read-only to you:
+
+  $ chmod 700 ~/.ssh
+  $ chmod 600 #{private_key_path}
+
+You can now access the inception server running:
+
+  $ ssh #{name}
+EOS
+    end
+
     no_tasks do
       def configure_provider
         save_settings!


### PR DESCRIPTION
inception share-ssh - easy access to inception server with others

Displays everything needed to show someone else how to access the inception
server.

Usage:

```
$ inception share-ssh
$ inception share-ssh company-xyz
```
