### PR TITLE
Added libcrul

### DIFF
--- a/cookbooks/bosh_inception/recipes/packages.rb
+++ b/cookbooks/bosh_inception/recipes/packages.rb
@@ -11,7 +11,7 @@ include_recipe "apt"
 
 %w[
   build-essential libsqlite3-dev curl rsync git-core
-  libmysqlclient-dev libxml2-dev libxslt-dev libpq-dev libsqlite3-dev
+  libmysqlclient-dev libxml2-dev libxslt-dev libpq-dev libsqlite3-dev libcurl4-gnutls-dev
   runit
   genisoimage
   debootstrap kpartx qemu-kvm


### PR DESCRIPTION
While I was installing cf-services-contrib-release gems on the inception server I encountered:

```
An error occurred while installing curb (0.7.18), and Bundler cannot continue.
Make sure that `gem install curb -v '0.7.18'` succeeds before bundling.
```

This was solved by installing `libcurl4-gnutls-dev`.
