### PR TITLE
attached disk improvements

### DIFF
--- a/Berksfile
+++ b/Berksfile
@@ -3,6 +3,6 @@ site :opscode
 cookbook "apt"
 cookbook "user"
 cookbook "sudo"
-cookbook "hub"
+cookbook "hub", github: "drnic/chef-hub"
 cookbook "chruby", github: 'Atalanta/chef-chruby', ref: '1942bf89'
 cookbook "bosh_inception", path: "cookbooks/bosh_inception"

--- a/Berksfile.lock
+++ b/Berksfile.lock
@@ -10,7 +10,9 @@
       "locked_version": "2.1.2"
     },
     "hub": {
-      "locked_version": "1.0.4"
+      "locked_version": "1.0.4",
+      "git": "git://github.com/drnic/chef-hub.git",
+      "ref": "bbfe752f3f12c4c6e1270c0e838098a8155f1385"
     },
     "chruby": {
       "locked_version": "0.2.1",

--- a/cookbooks/bosh_inception/attributes/default.rb
+++ b/cookbooks/bosh_inception/attributes/default.rb
@@ -3,9 +3,9 @@
 default["disk"]["mounted"] = false
 default["disk"]["device"] = "/dev/xvdf"
 default["disk"]["fstype"] = "btrfs"
-default["disk"]["dir"] = "/var/vcap/store"
 default["user"]["username"] = `users | head -n 1`.strip
 default["user"]["home"] = node.user.username == "root" ? "/root" : "/home/#{node["user"]["username"]}"
+default["disk"]["dir"] = "#{node.user.home}/bosh-workspace"
 default["git"]["name"] = "Nobody"
 default["git"]["email"] = "nobody@in-the-house.com"
 

--- a/cookbooks/bosh_inception/files/default/Gemfile.cf
+++ b/cookbooks/bosh_inception/files/default/Gemfile.cf
@@ -1,5 +1,4 @@
 source 'https://rubygems.org'
-source 'https://s3.amazonaws.com/bosh-jenkins-gems/'
 
 gem "bosh-bootstrap"
 gem "bosh-cloudfoundry"

--- a/cookbooks/bosh_inception/files/default/Gemfile.micro
+++ b/cookbooks/bosh_inception/files/default/Gemfile.micro
@@ -1,5 +1,4 @@
 source 'https://rubygems.org'
-source 'https://s3.amazonaws.com/bosh-jenkins-gems/'
 
 gem "bosh_cli", "~> 1.5.0.pre"
 gem "bosh_cli_plugin_micro", "~> 1.5.0.pre"

--- a/cookbooks/bosh_inception/recipes/install_bosh.rb
+++ b/cookbooks/bosh_inception/recipes/install_bosh.rb
@@ -1,11 +1,11 @@
-cookbook_file "/var/vcap/store/microboshes/Gemfile" do
+cookbook_file "#{node.disk.dir}/microboshes/Gemfile" do
   source "Gemfile.micro"
   owner node.user.username
   group node.user.username
   mode "0644"
 end
 
-directory "/var/vcap/store/microboshes" do
+directory "#{node.disk.dir}/microboshes" do
   owner node.user.username
   group node.user.username
   mode "0755"
@@ -14,13 +14,13 @@ directory "/var/vcap/store/microboshes" do
 end
 
 bash "install bosh micro" do
-  cwd "/var/vcap/store/microboshes"
+  cwd "#{node.disk.dir}/microboshes"
   user node.user.username
   code "source /etc/profile.d/chruby.sh; bundle install"
   action :run
 end
 
-cookbook_file "/var/vcap/store/systems/Gemfile" do
+cookbook_file "#{node.disk.dir}/systems/Gemfile" do
   source "Gemfile.cf"
   owner node.user.username
   group node.user.username
@@ -28,7 +28,7 @@ cookbook_file "/var/vcap/store/systems/Gemfile" do
 end
 
 bash "install bosh cf" do
-  cwd "/var/vcap/store/systems"
+  cwd "#{node.disk.dir}/systems"
   user node.user.username
   code "source /etc/profile.d/chruby.sh; bundle install"
   action :run

--- a/cookbooks/bosh_inception/recipes/mount_store_volume.rb
+++ b/cookbooks/bosh_inception/recipes/mount_store_volume.rb
@@ -1,24 +1,28 @@
 if node.disk.mounted
-  package "btrfs-tools" if node.disk.fstype == "btrfs"
+  if File.exist?(node.disk.device)
+    package "btrfs-tools" if node.disk.fstype == "btrfs"
 
-  bash "format /var/vcap/store partition" do
-    code "mkfs.#{node.disk.fstype} #{node.disk.device}"
-    not_if "cat /proc/mounts | grep /var/vcap/store"
-  end
+    bash "format /var/vcap/store partition" do
+      code "mkfs.#{node.disk.fstype} #{node.disk.device}"
+      not_if "cat /proc/mounts | grep /var/vcap/store"
+    end
 
-  directory node.disk.dir do
-    owner "root"
-    group "root"
-    mode "0755"
-    recursive true
-    action :create
-  end
+    directory node.disk.dir do
+      owner "root"
+      group "root"
+      mode "0755"
+      recursive true
+      action :create
+    end
 
-  mount node.disk.dir do
-    device node.disk.device
-    options "rw noatime"
-    fstype node.disk.fstype
-    action [ :enable, :mount ]
-    not_if "cat /proc/mounts | grep /var/vcap/store"
+    mount node.disk.dir do
+      device node.disk.device
+      options "rw noatime"
+      fstype node.disk.fstype
+      action [ :enable, :mount ]
+      not_if "cat /proc/mounts | grep /var/vcap/store"
+    end
+  else
+    $stderr.puts "Skipping mounting volume as cannot find #{node.disk.device}"
   end
 end

--- a/cookbooks/bosh_inception/recipes/mount_store_volume.rb
+++ b/cookbooks/bosh_inception/recipes/mount_store_volume.rb
@@ -2,9 +2,9 @@ if node.disk.mounted
   if File.exist?(node.disk.device)
     package "btrfs-tools" if node.disk.fstype == "btrfs"
 
-    bash "format /var/vcap/store partition" do
+    bash "format #{node.disk.dir} partition" do
       code "mkfs.#{node.disk.fstype} #{node.disk.device}"
-      not_if "cat /proc/mounts | grep /var/vcap/store"
+      not_if "cat /proc/mounts | grep #{node.disk.dir}"
     end
 
     directory node.disk.dir do
@@ -20,7 +20,7 @@ if node.disk.mounted
       options "rw noatime"
       fstype node.disk.fstype
       action [ :enable, :mount ]
-      not_if "cat /proc/mounts | grep /var/vcap/store"
+      not_if "cat /proc/mounts | grep #{node.disk.dir}"
     end
   else
     $stderr.puts "Skipping mounting volume as cannot find #{node.disk.device}"

--- a/cookbooks/bosh_inception/recipes/packages.rb
+++ b/cookbooks/bosh_inception/recipes/packages.rb
@@ -16,7 +16,7 @@ include_recipe "apt"
   genisoimage
   debootstrap kpartx qemu-kvm
   whois
-  tmux mosh
+  tmux
   vim
 ].each do |pkg|
   package pkg

--- a/cookbooks/bosh_inception/recipes/useful_dirs.rb
+++ b/cookbooks/bosh_inception/recipes/useful_dirs.rb
@@ -1,5 +1,5 @@
 %w[microboshes microboshes/deployments deployments releases repos stemcells systems tmp bosh_cache].each do |dir|
-  directory "/var/vcap/store/#{dir}" do
+  directory "#{node.disk.dir}/#{dir}" do
     owner node.user.username
     group node.user.username
     mode "0755"
@@ -9,5 +9,5 @@
 end
 
 link "#{node["user"]["home"]}/.bosh_cache" do
-  to "/var/vcap/store/bosh_cache"
+  to "#{node.disk.dir}/bosh_cache"
 end

--- a/lib/inception/inception_server.rb
+++ b/lib/inception/inception_server.rb
@@ -194,7 +194,7 @@ module Inception
     end
 
     def default_disk_device
-      @provider_client.default_disk_device
+      @provider_client.default_disk_device(fog_server)
     end
 
     def user_host

--- a/lib/inception/providers/clients/aws_provider_client.rb
+++ b/lib/inception/providers/clients/aws_provider_client.rb
@@ -121,7 +121,7 @@ class Inception::Providers::Clients::AwsProviderClient < Inception::Providers::C
     image_id || raise("Please add Ubuntu 13.04 64bit (EBS) AMI image id to aws.rb#raring_image_id method for region '#{region}'")
   end
 
-  def default_disk_device
+  def default_disk_device(server)
     { "external" => "/dev/sdf", "internal" => "/dev/xvdf" }
   end
 

--- a/lib/inception/providers/clients/fog_provider_client.rb
+++ b/lib/inception/providers/clients/fog_provider_client.rb
@@ -34,7 +34,7 @@ class Inception::Providers::Clients::FogProviderClient
     # override if supported
   end
 
-  def default_disk_device
+  def default_disk_device(server)
     raise "must implement"
   end
 

--- a/test/integration/default/bats/useful_dirs.bats
+++ b/test/integration/default/bats/useful_dirs.bats
@@ -3,6 +3,6 @@
 @test "use file dirs created" {
   for dir in microboshes/deployments deployments releases repos stemcells systems tmp bosh_cache
   do
-    [ -d /var/vcap/store/$dir ]
+    [ -d /home/vcap/bosh-workspace/$dir ]
   done
 }

--- a/test/integration/default/bats/user.bats
+++ b/test/integration/default/bats/user.bats
@@ -4,6 +4,6 @@ load discover_user
 
 @test "~/.bosh_cache symlink" {
   run su - $TEST_USER -c "readlink ~/.bosh_cache"
-  [ "${lines[0]}" = "/var/vcap/store/bosh_cache" ]
+  [ "${lines[0]}" = "/home/vcap/bosh-workspace/bosh_cache" ]
 }
 

--- a/test/integration/default/bats/verify_bosh.bats
+++ b/test/integration/default/bats/verify_bosh.bats
@@ -3,16 +3,16 @@
 load discover_user
 
 @test "bosh micro installed" {
-  run su - $TEST_USER -c "cd /var/vcap/store/microboshes; bundle exec bosh micro"
+  run su - $TEST_USER -c "cd /home/vcap/bosh-workspace/microboshes; bundle exec bosh micro"
   [ "$status" -eq 0 ]
 }
 
 @test "bosh-bootstrap installed" {
-  run su - $TEST_USER -c "cd /var/vcap/store/systems; bundle exec bosh-bootstrap"
+  run su - $TEST_USER -c "cd /home/vcap/bosh-workspace/systems; bundle exec bosh-bootstrap"
   [ "$status" -eq 0 ]
 }
 
 @test "bosh-cloudfoundry installed" {
-  run su - $TEST_USER -c "cd /var/vcap/store/systems; bundle exec bosh cf"
+  run su - $TEST_USER -c "cd /home/vcap/bosh-workspace/systems; bundle exec bosh cf"
   [ "$status" -eq 0 ]
 }


### PR DESCRIPTION
- If ephemeral disk missing, still successfully mount attached disk
- attached disk now at ~/bosh-workspace instead of /var/vcap/store - to match docs.cloudfoundry.com
