### PR TITLE
Image selection for OpenStack

### DIFF
--- a/inception-server.gemspec
+++ b/inception-server.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |spec|
 
   # for inception/providers
   spec.add_dependency "fog"
-  spec.add_dependency "cyoi" # choose your own infrastructure
+  spec.add_dependency "cyoi", "~> 0.6.0" # choose your own infrastructure
 
   # for running cookbooks on inception server
   spec.add_dependency "knife-solo", "~> 0.3.0"

--- a/lib/inception/cli.rb
+++ b/lib/inception/cli.rb
@@ -5,6 +5,7 @@ require "json"
 
 # to prompt user for infrastructure choice/credentials
 require "cyoi/cli/provider"
+require "cyoi/cli/image"
 
 # for the #sh helper
 require "rake"
@@ -30,6 +31,7 @@ module Inception
     def deploy
       migrate_old_settings
       configure_provider
+      configure_image
       prepare_deploy_settings
       perform_deploy
       converge_cookbooks
@@ -98,6 +100,16 @@ EOS
         provider_cli = Cyoi::Cli::Provider.new([settings_dir])
         provider_cli.execute!
         reload_settings!
+      end
+
+      def configure_image
+        save_settings!
+        image_cli = Cyoi::Cli::Image.new([settings_dir])
+        image_cli.execute!
+        reload_settings!
+        settings["inception"] ||= {}
+        settings["inception"]["image_id"] = settings.image.image_id
+        save_settings!
       end
 
       # update settings.git.name/git.email from local ~/.gitconfig if available

--- a/lib/inception/inception_server.rb
+++ b/lib/inception/inception_server.rb
@@ -167,7 +167,7 @@ module Inception
     end
 
     def image_id
-      @attributes["image_id"] ||= @provider_client.image_id
+      @attributes["image_id"]
     end
 
     # The progresive/final attributes of the provisioned Inception server &

--- a/lib/inception/providers/clients/aws_provider_client.rb
+++ b/lib/inception/providers/clients/aws_provider_client.rb
@@ -96,31 +96,6 @@ class Inception::Providers::Clients::AwsProviderClient < Inception::Providers::C
     volume
   end
 
-  # Ubuntu 13.04
-  def image_id
-    region = fog_compute.region
-    # http://cloud-images.ubuntu.com/locator/ec2/
-    image_id = case region.to_s
-    when "ap-northeast-1"
-      "ami-6b26ab6a"
-    when "ap-southeast-1"
-      "ami-2b511e79"
-    when "eu-west-1"
-      "ami-3d160149"
-    when "sa-east-1"
-      "ami-28e43e35"
-    when "us-east-1"
-      "ami-c30360aa"
-    when "us-west-1"
-      "ami-d383af96"
-    when "ap-southeast-2"
-      "ami-84a333be"
-    when "us-west-2"
-      "ami-bf1d8a8f"
-    end
-    image_id || raise("Please add Ubuntu 13.04 64bit (EBS) AMI image id to aws.rb#raring_image_id method for region '#{region}'")
-  end
-
   def default_disk_device(server)
     { "external" => "/dev/sdf", "internal" => "/dev/xvdf" }
   end

--- a/lib/inception/providers/clients/openstack_provider_client.rb
+++ b/lib/inception/providers/clients/openstack_provider_client.rb
@@ -66,10 +66,6 @@ class Inception::Providers::Clients::OpenStackProviderClient < Inception::Provid
     volume
   end
 
-  def image_id
-    raise "Not yet implemented: add inception.image_id & inception.initial_user and re-run 'inception deploy'"
-  end
-
   def default_disk_device(server)
     if server_ephemeral_disk?(server)
       { "external" => "/dev/vdc", "internal" => "/dev/vdc" }


### PR DESCRIPTION
AWS continues to default to an Ubuntu 13.04 public AMI. OpenStack support implemented in cyoi 0.6.0
