### PR TITLE
Give VM time to boot before SSH connection timeout

### DIFF
--- a/cookbooks/bosh_inception/files/default/Gemfile.micro
+++ b/cookbooks/bosh_inception/files/default/Gemfile.micro
@@ -1,3 +1,4 @@
 source 'https://rubygems.org'
 
 gem "bosh_cli_plugin_micro", "~> 1.2005"
+gem "cyoi", "~> 0.7" # cyoi 0.8.3 fails to create security_group_rules for OpenStack

--- a/lib/inception/providers/clients/fog_provider_client.rb
+++ b/lib/inception/providers/clients/fog_provider_client.rb
@@ -195,7 +195,7 @@ class Inception::Providers::Clients::FogProviderClient
 
       attach_public_ip_address(server, public_ip_address)
 
-      server.setup(keys: [private_key_path])
+      server.setup(keys: [private_key_path], timeout: 300)
     end
     server
   end


### PR DESCRIPTION
My VMs take a long time to boot up, > 30 seconds

I initially tried setting "ConnectTimeout 120" in my .ssh/config file, but that didn't work.

It looks like fog has a default value of 30 seconds set in fog-core-1.21.1/lib/fog/core/ssh.rb:49
options[:timeout] ||= 30

This might be overriding the default SSH timeout in .ssh/config?

This should be fixed in Fog?; or, allow the config setting in .inception_server/settings.yml?

```
bundle exec bin/inception deploy
Auto-detected infrastructure API credentials at ~/.fog (override with $FOG)
1. OpenStack (default)
2. Alternate credentials
Choose an auto-detected infrastructure: 1

Using provider OpenStack
OpenStack Region (optional): 

Confirming: Using OpenStack (user: admin)
1. ubuntu-12.04-server-cloudimg-amd64
Choose image: 1

Confirming: Using image 64af03a1-07d0-4dce-87bb-2568613c912b

Preparing deployment settings

Using your git user.name (Benjamin Cavileer)
Acquiring a public IP address... 192.168.1.228

Provision inception server

Reusing security group ssh
Booting m1.small inception server... /home/benjamin/.rvm/gems/ruby-1.9.3-p545@bosh/gems/net-ssh-2.8.0/lib/net/ssh/transport/session.rb:70:in `initialize': execution expired (Timeout::Error)
    from /home/benjamin/.rvm/gems/ruby-1.9.3-p545@bosh/gems/net-ssh-2.8.0/lib/net/ssh/transport/session.rb:70:in `open'
    from /home/benjamin/.rvm/gems/ruby-1.9.3-p545@bosh/gems/net-ssh-2.8.0/lib/net/ssh/transport/session.rb:70:in `block in initialize'
    from /home/benjamin/.rvm/gems/ruby-1.9.3-p545@bosh/gems/net-ssh-2.8.0/lib/net/ssh/transport/session.rb:67:in `initialize'
    from /home/benjamin/.rvm/gems/ruby-1.9.3-p545@bosh/gems/net-ssh-2.8.0/lib/net/ssh.rb:200:in `new'
    from /home/benjamin/.rvm/gems/ruby-1.9.3-p545@bosh/gems/net-ssh-2.8.0/lib/net/ssh.rb:200:in `start'
    from /home/benjamin/.rvm/gems/ruby-1.9.3-p545@bosh/gems/fog-core-1.21.1/lib/fog/core/ssh.rb:67:in `run'
    from /home/benjamin/.rvm/gems/ruby-1.9.3-p545@bosh/gems/fog-1.21.0/lib/fog/openstack/models/compute/server.rb:329:in `setup'
    from /home/benjamin/bosh/inception-server/lib/inception/providers/clients/fog_provider_client.rb:198:in `bootstrap'
    from /home/benjamin/bosh/inception-server/lib/inception/inception_server.rb:256:in `bootstrap_vm'
    from /home/benjamin/bosh/inception-server/lib/inception/inception_server.rb:66:in `create'
    from /home/benjamin/bosh/inception-server/lib/inception/cli.rb:131:in `perform_deploy'
    from /home/benjamin/bosh/inception-server/lib/inception/cli.rb:36:in `deploy'
    from /home/benjamin/.rvm/gems/ruby-1.9.3-p545@bosh/gems/thor-0.18.1/lib/thor/command.rb:27:in `run'
    from /home/benjamin/.rvm/gems/ruby-1.9.3-p545@bosh/gems/thor-0.18.1/lib/thor/invocation.rb:120:in `invoke_command'
    from /home/benjamin/.rvm/gems/ruby-1.9.3-p545@bosh/gems/thor-0.18.1/lib/thor.rb:363:in `dispatch'
    from /home/benjamin/.rvm/gems/ruby-1.9.3-p545@bosh/gems/thor-0.18.1/lib/thor/base.rb:439:in `start'
    from bin/inception:8:in `<main>'
```
