### PR TITLE
Remove unused hub dependency.

### DIFF
--- a/Berksfile
+++ b/Berksfile
@@ -3,6 +3,5 @@ site :opscode
 cookbook "apt"
 cookbook "user"
 cookbook "sudo"
-cookbook "hub", github: "drnic/chef-hub"
 cookbook "chruby", github: 'Atalanta/chef-chruby', ref: '1942bf89'
 cookbook "bosh_inception", path: "cookbooks/bosh_inception"

--- a/Berksfile.lock
+++ b/Berksfile.lock
@@ -6,9 +6,6 @@ DEPENDENCIES
     git: git://github.com/Atalanta/chef-chruby.git
     revision: 1942bf895b30b6173249d2a50f35e8efca1afc08
     ref: 1942bf8
-  hub
-    git: git://github.com/drnic/chef-hub.git
-    revision: bbfe752f3f12c4c6e1270c0e838098a8155f1385
   sudo
   user
 
@@ -22,13 +19,11 @@ GRAPH
   bosh_inception (0.1.0)
     apt (>= 0.0.0)
     chruby (>= 0.0.0)
-    hub (>= 0.0.0)
     sudo (>= 0.0.0)
   chef_handler (1.1.6)
   chruby (0.2.1)
     ark (>= 0.0.0)
     ruby_build (>= 0.0.0)
-  hub (1.0.4)
   ruby_build (0.8.0)
   sudo (2.7.1)
   user (0.3.0)

--- a/cookbooks/bosh_inception/metadata.rb
+++ b/cookbooks/bosh_inception/metadata.rb
@@ -10,7 +10,6 @@ supports "ubuntu"
 depends "apt"
 depends "sudo"
 depends "chruby"
-depends "hub"
 
 attribute "git",
   display_name: "Git",

--- a/cookbooks/bosh_inception/recipes/setup_git.rb
+++ b/cookbooks/bosh_inception/recipes/setup_git.rb
@@ -7,8 +7,6 @@
 # MIT License
 #
 
-include_recipe "hub"
-
 execute "git config user.name" do
   command "git config --global --replace-all user.name '#{node.git.name}'"
   user node.user.username


### PR DESCRIPTION
Hub is breaking the provisioning of the inception server, because it requires Go (as reported in #69). But at the moment, correct me if I am wrong, it seems that hub is not required at all.
This PR removes the dependency.
Please keep in mind that I was not able to test it.
